### PR TITLE
use safe indexing

### DIFF
--- a/dabl/search.py
+++ b/dabl/search.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import numpy as np
 from sklearn.model_selection._search import _check_param_grid
 from sklearn.model_selection import ParameterGrid, ParameterSampler
-from sklearn.utils import check_random_state
+from sklearn.utils import check_random_state, safe_indexing
 from sklearn.base import is_classifier
 from sklearn.model_selection._split import check_cv
 
@@ -211,7 +211,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
                 # train_test_split because it complains about testset being too
                 # small in some cases
                 indexes = rng.choice(X.shape[0], r_i)
-                X_iter, y_iter = X[indexes], y[indexes]
+                X_iter, y_iter = safe_indexing(X, indexes), safe_indexing(y, indexes)
             else:
                 # Need copy so that r_i of next iteration do not overwrite
                 candidate_params = [c.copy() for c in candidate_params]


### PR DESCRIPTION
@NicolasHug I think we need this, but it still doesn't work for pandas dataframe input.

```python
from sklearn.pipeline import make_pipeline
from scipy import stats
from sklearn.model_selection import GridSearchCV
from dabl import EasyPreprocessor
from dabl.preprocessing import clean
from sklearn.tree import DecisionTreeClassifier
import sklearn
sklearn.set_config(print_changed_only=True)

data = pd.read_csv("/home/andy/datasets/adult.csv")
data = pd.read_csv("https://github.com/amueller/ml-workshop-3-of-4/raw/master/notebooks/data/adult.csv")
target = 'income'

param_grid = {'decisiontreeclassifier__max_leaf_nodes': []}
pipe = make_pipeline(EasyPreprocessor(), DecisionTreeClassifier(max_leaf_nodes=100))

from dabl import RandomSuccessiveHalving
param_dist = {'decisiontreeclassifier__max_leaf_nodes': stats.randint(2, 500)}

data = clean(data)
sh.fit(data.drop(target, axis=1), data[target])
```

this gets some duplicate index errors and in the last iteration all scores are nan :-/