### PR TITLE
style: Fix typo in docstrings and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The data analysis baseline library.
 This is pre-alpha software and is still very-much in flux.
 
 ## Current scope and upcoming features
-This library is very much still under development. Current code focusses mostly on exploratory visualiation and preprocessing.
+This library is very much still under development. Current code focuses mostly on exploratory visualiation and preprocessing.
 There are also drop-in replacements for GridSearchCV and RandomizedSearchCV using successive halfing.
 The next step in the development will be adding portfolios in the style of
 [POSH

--- a/dabl/models.py
+++ b/dabl/models.py
@@ -62,7 +62,7 @@ class _BaseSimpleEstimator(BaseEstimator):
     def _fit(self, X, y=None, target_col=None):
         """Fit estimator.
 
-        Requiers to either specify the target as seperate 1d array or Series y
+        Requiers to either specify the target as separate 1d array or Series y
         (in scikit-learn fashion) or as column of the dataframe X specified by
         target_col.
         If y is specified, X is assumed not to contain the target.
@@ -181,7 +181,7 @@ class SimpleClassifier(_BaseSimpleEstimator, ClassifierMixin):
     def fit(self, X, y=None, target_col=None):
         """Fit classifier.
 
-        Requires to either specify the target as seperate 1d array or Series y
+        Requires to either specify the target as separate 1d array or Series y
         (in scikit-learn fashion) or as column of the dataframe X specified by
         target_col.
         If y is specified, X is assumed not to contain the target.
@@ -235,7 +235,7 @@ class SimpleRegressor(_BaseSimpleEstimator, RegressorMixin):
     def fit(self, X, y=None, target_col=None):
         """Fit regressor.
 
-        Requires to either specify the target as seperate 1d array or Series y
+        Requires to either specify the target as separate 1d array or Series y
         (in scikit-learn fashion) or as column of the dataframe X specified by
         target_col.
         If y is specified, X is assumed not to contain the target.

--- a/dabl/plot/utils.py
+++ b/dabl/plot/utils.py
@@ -87,7 +87,7 @@ def plot_coefficients(coefficients, feature_names, n_top_features=10,
     feature_names = np.asarray(feature_names)
     if coefficients.ndim > 1:
         # this is not a row or column vector
-        raise ValueError("coeffients must be 1d array or column vector, got"
+        raise ValueError("coefficients must be 1d array or column vector, got"
                          " shape {}".format(coefficients.shape))
     coefficients = coefficients.ravel()
 

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -437,7 +437,7 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
     max_budget_ : int
         The maximum number of resources that any candidate is allowed to use
         for a given iteration. Note that since the number of resources used at
-        each iteration must be a mulitple of ``r_min_``, the actual number of
+        each iteration must be a multiple of ``r_min_``, the actual number of
         resources used at the last iteartion may be smaller than
         ``max_budget_``.
 
@@ -794,7 +794,7 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
     max_budget_ : int
         The maximum number of resources that any candidate is allowed to use
         for a given iteration. Note that since the number of resources used at
-        each iteration must be a mulitple of ``r_min_``, the actual number of
+        each iteration must be a multiple of ``r_min_``, the actual number of
         resources used at the last iteartion may be smaller than
         ``max_budget_``.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ A full guide to the main concepts and ideas of the dabl.
 `API Documentation <api.html>`_
 -------------------------------
 
-A documentation of all the dabl classes and fuctions.
+A documentation of all the dabl classes and functions.
 
 `Examples <auto_examples/index.html>`_
 --------------------------------------

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -137,7 +137,7 @@ This again is a good place to surface data leakage, as well as find the main
 discriminative features in the dataset.  The ``SimpleClassifier`` allows
 specifying data in the scikit-learn-style ``fit(X, y)`` with a 1d y and
 features ``X``, or with ``X`` being a dataframe, and by specifying the target
-column insided of X as``target_col``.
+column inside of X as``target_col``.
 
 The SimpleClassifier also performs preprocessing such as missing value
 imputation and one-hot-encoding.  You can inspect the model using:


### PR DESCRIPTION
Issues were identified using the open-source tool codespell [1]
running the following command from the source directory:

[1] https://github.com/codespell-project/codespell#readme

```
$ codespell -q6 \
  --skip="./dabl/datasets" \
  --write-changes \
  --summary

[...]

-------8<-------
SUMMARY:
coeffients    1
focusses      1
fuctions      1
insided       1
mulitple      2
seperate      3
```