### PR TITLE
[MRG] Cleaning of successive halving

### DIFF
--- a/dabl/_resample.py
+++ b/dabl/_resample.py
@@ -1,0 +1,160 @@
+# FIXME remove when/if sklearn PR #13549 is merged
+# We need this to subsample arrays with stratification
+
+import numpy as np
+from scipy.sparse import issparse
+from sklearn.utils import safe_indexing
+from sklearn.utils import check_random_state
+from sklearn.utils.validation import check_consistent_length
+from sklearn.model_selection._split import _approximate_mode
+
+
+def resample(*arrays, **options):
+
+    """Resample arrays or sparse matrices in a consistent way
+
+    The default strategy implements one step of the bootstrapping
+    procedure.
+
+    Parameters
+    ----------
+    *arrays : sequence of indexable data-structures
+        Indexable data-structures can be arrays, lists, dataframes or scipy
+        sparse matrices with consistent first dimension.
+
+    Other Parameters
+    ----------------
+    replace : boolean, True by default
+        Implements resampling with replacement. If False, this will implement
+        (sliced) random permutations.
+
+    n_samples : int, None by default
+        Number of samples to generate. If left to None this is
+        automatically set to the first dimension of the arrays.
+        If replace is False it should not be larger than the length of
+        arrays.
+
+    random_state : int, RandomState instance or None, optional (default=None)
+        The seed of the pseudo random number generator to use when shuffling
+        the data.  If int, random_state is the seed used by the random number
+        generator; If RandomState instance, random_state is the random number
+        generator; If None, the random number generator is the RandomState
+        instance used by `np.random`.
+
+    stratify : array-like or None (default=None)
+        If not None, data is split in a stratified fashion, using this as
+        the class labels.
+
+    Returns
+    -------
+    resampled_arrays : sequence of indexable data-structures
+        Sequence of resampled copies of the collections. The original arrays
+        are not impacted.
+
+    Examples
+    --------
+    It is possible to mix sparse and dense arrays in the same run::
+
+      >>> X = np.array([[1., 0.], [2., 1.], [0., 0.]])
+      >>> y = np.array([0, 1, 2])
+
+      >>> from scipy.sparse import coo_matrix
+      >>> X_sparse = coo_matrix(X)
+
+      >>> from sklearn.utils import resample
+      >>> X, X_sparse, y = resample(X, X_sparse, y, random_state=0)
+      >>> X
+      array([[1., 0.],
+             [2., 1.],
+             [1., 0.]])
+
+      >>> X_sparse                   # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+      <3x2 sparse matrix of type '<... 'numpy.float64'>'
+          with 4 stored elements in Compressed Sparse Row format>
+
+      >>> X_sparse.toarray()
+      array([[1., 0.],
+             [2., 1.],
+             [1., 0.]])
+
+      >>> y
+      array([0, 1, 0])
+
+      >>> resample(y, n_samples=2, random_state=0)
+      array([0, 1])
+
+
+    See also
+    --------
+    :func:`sklearn.utils.shuffle`
+    """
+
+    random_state = check_random_state(options.pop('random_state', None))
+    replace = options.pop('replace', True)
+    max_n_samples = options.pop('n_samples', None)
+    stratify = options.pop('stratify', None)
+    if options:
+        raise ValueError("Unexpected kw arguments: %r" % options.keys())
+
+    if len(arrays) == 0:
+        return None
+
+    first = arrays[0]
+    n_samples = first.shape[0] if hasattr(first, 'shape') else len(first)
+
+    if max_n_samples is None:
+        max_n_samples = n_samples
+    elif (max_n_samples > n_samples) and (not replace):
+        raise ValueError("Cannot sample %d out of arrays with dim %d "
+                         "when replace is False" % (max_n_samples,
+                                                    n_samples))
+
+    check_consistent_length(*arrays)
+
+    if stratify is None:
+        if replace:
+            indices = random_state.randint(0, n_samples, size=(max_n_samples,))
+        else:
+            indices = np.arange(n_samples)
+            random_state.shuffle(indices)
+            indices = indices[:max_n_samples]
+    else:
+        # Code adapted from StratifiedShuffleSplit()
+        y = stratify
+        if y.ndim == 2:
+            # for multi-label y, map each distinct row to a string repr
+            # using join because str(row) uses an ellipsis if len(row) > 1000
+            y = np.array([' '.join(row.astype('str')) for row in y])
+
+        classes, y_indices = np.unique(y, return_inverse=True)
+        n_classes = classes.shape[0]
+
+        class_counts = np.bincount(y_indices)
+
+        # Find the sorted list of instances for each class:
+        # (np.unique above performs a sort, so code is O(n logn) already)
+        class_indices = np.split(np.argsort(y_indices, kind='mergesort'),
+                                 np.cumsum(class_counts)[:-1])
+
+        # if there are ties in the class-counts, we want
+        # to make sure to break them anew in each iteration
+        n_i = _approximate_mode(class_counts, max_n_samples, random_state)
+
+        indices = []
+
+        for i in range(n_classes):
+            indices_i = random_state.choice(class_indices[i], n_i[i],
+                                            replace=replace)
+            indices.extend(indices_i)
+
+        indices = random_state.permutation(indices)
+
+
+    # convert sparse matrices to CSR for row-based indexing
+    arrays = [a.tocsr() if issparse(a) else a for a in arrays]
+    resampled_arrays = [safe_indexing(a, indices) for a in arrays]
+    if len(resampled_arrays) == 1:
+        # syntactic sugar for the unit argument case
+        return resampled_arrays[0]
+    else:
+        return resampled_arrays

--- a/dabl/_search.py
+++ b/dabl/_search.py
@@ -274,6 +274,8 @@ class CustomBaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 refit_metric = self.refit
         else:
             refit_metric = 'score'
+        print(refit_metric)
+        self.refit_metric = refit_metric
 
         X, y, groups = indexable(X, y, groups)
         n_splits = cv.get_n_splits(X, y, groups)

--- a/dabl/_search.py
+++ b/dabl/_search.py
@@ -274,7 +274,6 @@ class CustomBaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 refit_metric = self.refit
         else:
             refit_metric = 'score'
-        print(refit_metric)
         self.refit_metric = refit_metric
 
         X, y, groups = indexable(X, y, groups)

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -34,7 +34,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
     Zohar Karnin, Tomer Koren, Oren Somekh
     """
     def __init__(self, estimator,
-                 n_jobs=None, refit=True, cv=None, verbose=0,
+                 n_jobs=None, refit=True, cv=5, verbose=0,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,
@@ -297,11 +297,10 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, optional (default=5)
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
@@ -312,11 +311,6 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
-
-        # FIXME
-        .. versionchanged:: 0.20
-            ``cv`` default value if None will change from 3-fold to 5-fold
-            in v0.22.
 
     refit : boolean, default=True
         If True, refit an estimator using the best found parameters on the
@@ -526,7 +520,7 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
     """
 
     def __init__(self, estimator, param_grid,
-                 n_jobs=None, refit=True, verbose=0, cv=None,
+                 n_jobs=None, refit=True, verbose=0, cv=5,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,
@@ -599,7 +593,7 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
             - A string, giving an expression as a function of n_jobs,
               as in '2*n_jobs'
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, optional (default=5)
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -614,11 +608,6 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
-
-        # FIXME
-        .. versionchanged:: 0.20
-            ``cv`` default value if None will change from 3-fold to 5-fold
-            in v0.22.
 
     refit : boolean, default=True
         If True, refit an estimator using the best found parameters on the
@@ -829,7 +818,7 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
     """
 
     def __init__(self, estimator, param_distributions, n_candidates='auto',
-                 n_jobs=None, refit=True, verbose=0, cv=None,
+                 n_jobs=None, refit=True, verbose=0, cv=5,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -32,7 +32,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
     Almost optimal exploration in multi-armed bandits, ICML 13
     Zohar Karnin, Tomer Koren, Oren Somekh
     """
-    def __init__(self, estimator,
+    def __init__(self, estimator, scoring=None,
                  n_jobs=None, refit=True, cv=5, verbose=0,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
@@ -41,7 +41,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
                  force_exhaust_budget=False):
 
         refit = _refit_callable if refit else False
-        super().__init__(estimator,
+        super().__init__(estimator, scoring=scoring,
                          n_jobs=n_jobs, refit=refit, cv=cv,
                          verbose=verbose, pre_dispatch=pre_dispatch,
                          error_score=error_score,
@@ -56,6 +56,11 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
         self.force_exhaust_budget = force_exhaust_budget
 
     def _check_input_parameters(self, X, y, groups):
+
+        if self.scoring is not None and not (isinstance(self.scoring, str)
+                                             or callable(self.scoring)):
+            raise ValueError('scoring parameter must be a string, '
+                             'a callable or None.')
 
         if (self.budget_on != 'n_samples'
                 and self.budget_on not in self.estimator.get_params()):
@@ -167,6 +172,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
             n_iterations = min(n_possible_iterations, n_required_iterations)
 
         if self.verbose:
+            # FIXME: python 35
             print(f'n_iterations: {n_iterations}')
             print(f'n_required_iterations: {n_required_iterations}')
             print(f'n_possible_iterations: {n_possible_iterations}')
@@ -272,6 +278,11 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         dictionaries, in which case the grids spanned by each dictionary
         in the list are explored. This enables searching over any sequence
         of parameter settings.
+
+    scoring : string, callable, or None, default: None
+        A single string (see :ref:`scoring_parameter`) or a callable
+        (see :ref:`scoring`) to evaluate the predictions on the test set.
+        If None, the estimator's score method is used.
 
     n_jobs : int or None, optional (default=None)
         Number of jobs to run in parallel.
@@ -518,14 +529,14 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         Random search over a set of parameters using successive halving.
     """
 
-    def __init__(self, estimator, param_grid,
+    def __init__(self, estimator, param_grid, scoring=None,
                  n_jobs=None, refit=True, verbose=0, cv=5,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,
                  r_min='auto', aggressive_elimination=False,
                  force_exhaust_budget=False):
-        super().__init__(estimator,
+        super().__init__(estimator, scoring=scoring,
                          n_jobs=n_jobs, refit=refit, verbose=verbose, cv=cv,
                          pre_dispatch=pre_dispatch,
                          random_state=random_state, error_score=error_score,
@@ -568,6 +579,11 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         sample enough candidates so that the last iteration uses as many
         resources as possible. Note that ``force_exhaust_budget`` has no
         effect in this case.
+
+    scoring : string, callable, or None, default: None
+        A single string (see :ref:`scoring_parameter`) or a callable
+        (see :ref:`scoring`) to evaluate the predictions on the test set.
+        If None, the estimator's score method is used.
 
     n_jobs : int or None, optional (default=None)
         Number of jobs to run in parallel.
@@ -815,14 +831,14 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         Search over a grid of parameters using successive halving.
     """
 
-    def __init__(self, estimator, param_distributions, n_candidates='auto',
-                 n_jobs=None, refit=True, verbose=0, cv=5,
-                 pre_dispatch='2*n_jobs', random_state=None,
-                 error_score=np.nan, return_train_score=True,
-                 max_budget='auto', budget_on='n_samples', ratio=3,
-                 r_min='auto', aggressive_elimination=False,
-                 force_exhaust_budget=False):
-        super().__init__(estimator,
+    def __init__(self, estimator, param_distributions,
+                 n_candidates='auto', scoring=None, n_jobs=None, refit=True,
+                 verbose=0, cv=5, pre_dispatch='2*n_jobs',
+                 random_state=None, error_score=np.nan,
+                 return_train_score=True, max_budget='auto',
+                 budget_on='n_samples', ratio=3, r_min='auto',
+                 aggressive_elimination=False, force_exhaust_budget=False):
+        super().__init__(estimator, scoring=scoring,
                          n_jobs=n_jobs, refit=refit, verbose=verbose, cv=cv,
                          random_state=random_state, error_score=error_score,
                          return_train_score=return_train_score,

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -9,6 +9,7 @@ from sklearn.base import is_classifier
 from sklearn.model_selection._split import check_cv
 
 from ._search import CustomBaseSearchCV
+from ._resample import resample
 
 __all__ = ['GridSuccessiveHalving', 'RandomSuccessiveHalving']
 
@@ -211,13 +212,9 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
                 print(f'r_i (in r_min units): {r_i // self.r_min_}')
 
             if self.budget_on == 'n_samples':
-                # XXX FIXME TODO
-                # subsampling should be stratified. We can't use
-                # train_test_split because it complains about testset being too
-                # small in some cases
-                indexes = rng.choice(X.shape[0], r_i, replace=False)
-                X_iter = safe_indexing(X, indexes)
-                y_iter = safe_indexing(y, indexes)
+                stratify = y if is_classifier(self.estimator) else None
+                X_iter, y_iter = resample(X, y, replace=False,
+                                          random_state=rng, stratify=stratify)
             else:
                 # Need copy so that r_i of next iteration do not overwrite
                 candidate_params = [c.copy() for c in candidate_params]

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -173,15 +173,14 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
             n_iterations = min(n_possible_iterations, n_required_iterations)
 
         if self.verbose:
-            # FIXME: python 35
-            print(f'n_iterations: {n_iterations}')
-            print(f'n_required_iterations: {n_required_iterations}')
-            print(f'n_possible_iterations: {n_possible_iterations}')
-            print(f'r_min_: {self.r_min_}')
-            print(f'max_budget_: {self.max_budget_}')
-            print(f'aggressive_elimination: {self.aggressive_elimination}')
-            print(f'force_exhaust_budget: {self.force_exhaust_budget}')
-            print(f'ratio: {self.ratio}')
+            print('n_iterations: {}'.format(n_iterations))
+            print('n_required_iterations: {}'.format(n_required_iterations))
+            print('n_possible_iterations: {}'.format(n_possible_iterations))
+            print('r_min_: {}'.format(self.r_min_))
+            print('max_budget_: {}'.format(self.max_budget_))
+            print('aggressive_elimination: {}'.format(self.aggressive_elimination))
+            print('force_exhaust_budget: {}'.format(self.force_exhaust_budget))
+            print('ratio: {}'.format(self.ratio))
 
         self._r_i_list = []  # list of r_i for each iteration, used in tests
 
@@ -206,10 +205,9 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
 
             if self.verbose:
                 print('-' * 10)
-                print(f'iter_i: {iter_i}')
-                print(f'n_candidates: {n_candidates}')
-                print(f'r_i: {r_i}')
-                print(f'r_i (in r_min units): {r_i // self.r_min_}')
+                print('iter_i: {}'.format(iter_i))
+                print('n_candidates: {}'.format(n_candidates))
+                print('r_i: {}'.format(r_i))
 
             if self.budget_on == 'n_samples':
                 stratify = y if is_classifier(self.estimator) else None

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -428,7 +428,7 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         resources. This will be smaller than ``n_possible_iterations_`` when
         there isn't enough budget.
 
-    cv_results_ : dict of numpy (masked) ndarrays  # FIXME Update this
+    cv_results_ : dict of numpy (masked) ndarrays
         A dict with keys as column headers and values as columns, that can be
         imported into a pandas ``DataFrame``.
 
@@ -729,7 +729,7 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         resources. This will be smaller than ``n_possible_iterations_`` when
         there isn't enough budget.
 
-    cv_results_ : dict of numpy (masked) ndarrays  # FIXME Update this
+    cv_results_ : dict of numpy (masked) ndarrays
         A dict with keys as column headers and values as columns, that can be
         imported into a pandas ``DataFrame``.
 

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -22,6 +22,7 @@ def _refit_callable(results):
     sorted_indices = np.argsort(results['mean_test_score'])[::-1]
     best_index = next(i for i in sorted_indices
                       if results['iter'][i] == last_iter)
+    raise ValueError("QIPEGNQPEIGNQIPEGN")
     return best_index
 
 
@@ -32,7 +33,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
     Almost optimal exploration in multi-armed bandits, ICML 13
     Zohar Karnin, Tomer Koren, Oren Somekh
     """
-    def __init__(self, estimator, scoring=None,
+    def __init__(self, estimator,
                  n_jobs=None, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
@@ -41,7 +42,7 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
                  force_exhaust_budget=False):
 
         refit = _refit_callable if refit else False
-        super().__init__(estimator, scoring=scoring,
+        super().__init__(estimator,
                          n_jobs=n_jobs, refit=refit, cv=cv,
                          verbose=verbose, pre_dispatch=pre_dispatch,
                          error_score=error_score,
@@ -273,22 +274,6 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         in the list are explored. This enables searching over any sequence
         of parameter settings.
 
-    # FIXME (is this even supported??)
-    scoring : string, callable, list/tuple, dict or None, default: None
-        A single string (see :ref:`scoring_parameter`) or a callable
-        (see :ref:`scoring`) to evaluate the predictions on the test set.
-
-        For evaluating multiple metrics, either give a list of (unique) strings
-        or a dict with names as keys and callables as values.
-
-        NOTE that when using custom scorers, each scorer should return a single
-        value. Metric functions returning a list/array of values can be wrapped
-        into multiple scorers that return one value each.
-
-        See :ref:`multimetric_grid_search` for an example.
-
-        If None, the estimator's score method is used.
-
     n_jobs : int or None, optional (default=None)
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -333,30 +318,13 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
             ``cv`` default value if None will change from 3-fold to 5-fold
             in v0.22.
 
-    # FIXME
     refit : boolean, default=True
         If True, refit an estimator using the best found parameters on the
         whole dataset.
 
-        For multiple metric evaluation, this needs to be a string denoting the
-        scorer is used to find the best parameters for refitting the estimator
-        at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given ``cv_results_``.
-
         The refitted estimator is made available at the ``best_estimator_``
         attribute and permits using ``predict`` directly on this
         ``GridSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer. ``best_score_`` is not returned if refit is callable.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
 
     verbose : integer
         Controls the verbosity: the higher, the more messages.
@@ -507,32 +475,16 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
         ``std_score_time`` are all in seconds.
 
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
-
     best_estimator_ : estimator or dict
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data. Not available if ``refit=False``.
 
-        For multi-metric evaluation, this attribute is present only if
-        ``refit`` is specified.
-
-        See ``refit`` parameter for more information on allowed values.
-
     best_score_ : float
         Mean cross-validated score of the best_estimator.
 
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
     best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
 
     best_index_ : int
         The index (of the ``cv_results_`` arrays) which corresponds to the best
@@ -542,15 +494,9 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         the parameter setting for the best model, that gives the highest
         mean score (``search.best_score_``).
 
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
     scorer_ : function or a dict
         Scorer function used on the held out data to choose the best
         parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
@@ -579,15 +525,15 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         Random search over a set of parameters using successive halving.
     """
 
-    def __init__(self, estimator, param_grid, scoring=None,
+    def __init__(self, estimator, param_grid,
                  n_jobs=None, refit=True, verbose=0, cv=None,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,
                  r_min='auto', aggressive_elimination=False,
                  force_exhaust_budget=False):
-        super().__init__(estimator, scoring=scoring,
-                         n_jobs=n_jobs, verbose=verbose, cv=cv,
+        super().__init__(estimator,
+                         n_jobs=n_jobs, refit=refit, verbose=verbose, cv=cv,
                          pre_dispatch=pre_dispatch,
                          random_state=random_state, error_score=error_score,
                          return_train_score=return_train_score,
@@ -630,22 +576,6 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         resources as possible. Note that ``force_exhaust_budget`` has no
         effect in this case.
 
-    # FIXME (is this even supported??)
-    scoring : string, callable, list/tuple, dict or None, default: None
-        A single string (see :ref:`scoring_parameter`) or a callable
-        (see :ref:`scoring`) to evaluate the predictions on the test set.
-
-        For evaluating multiple metrics, either give a list of (unique) strings
-        or a dict with names as keys and callables as values.
-
-        NOTE that when using custom scorers, each scorer should return a single
-        value. Metric functions returning a list/array of values can be wrapped
-        into multiple scorers that return one value each.
-
-        See :ref:`multimetric_grid_search` for an example.
-
-        If None, the estimator's score method is used.
-
     n_jobs : int or None, optional (default=None)
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -690,30 +620,13 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
             ``cv`` default value if None will change from 3-fold to 5-fold
             in v0.22.
 
-    # FIXME
     refit : boolean, default=True
         If True, refit an estimator using the best found parameters on the
         whole dataset.
 
-        For multiple metric evaluation, this needs to be a string denoting the
-        scorer is used to find the best parameters for refitting the estimator
-        at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given ``cv_results_``.
-
         The refitted estimator is made available at the ``best_estimator_``
         attribute and permits using ``predict`` directly on this
         ``GridSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer. ``best_score_`` is not returned if refit is callable.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
 
     verbose : integer
         Controls the verbosity: the higher, the more messages.
@@ -864,32 +777,16 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
         ``std_score_time`` are all in seconds.
 
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
-
     best_estimator_ : estimator or dict
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
         on the left out data. Not available if ``refit=False``.
 
-        For multi-metric evaluation, this attribute is present only if
-        ``refit`` is specified.
-
-        See ``refit`` parameter for more information on allowed values.
-
     best_score_ : float
         Mean cross-validated score of the best_estimator.
 
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
     best_params_ : dict
         Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
 
     best_index_ : int
         The index (of the ``cv_results_`` arrays) which corresponds to the best
@@ -899,15 +796,10 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         the parameter setting for the best model, that gives the highest
         mean score (``search.best_score_``).
 
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
+    # FIXME really supported?
     scorer_ : function or a dict
         Scorer function used on the held out data to choose the best
         parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
 
     n_splits_ : int
         The number of cross-validation splits (folds/iterations).
@@ -937,14 +829,14 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
     """
 
     def __init__(self, estimator, param_distributions, n_candidates='auto',
-                 scoring=None, n_jobs=None, refit=True, verbose=0, cv=None,
+                 n_jobs=None, refit=True, verbose=0, cv=None,
                  pre_dispatch='2*n_jobs', random_state=None,
                  error_score=np.nan, return_train_score=True,
                  max_budget='auto', budget_on='n_samples', ratio=3,
                  r_min='auto', aggressive_elimination=False,
                  force_exhaust_budget=False):
-        super().__init__(estimator, scoring=scoring,
-                         n_jobs=n_jobs, verbose=verbose, cv=cv,
+        super().__init__(estimator,
+                         n_jobs=n_jobs, refit=refit, verbose=verbose, cv=cv,
                          random_state=random_state, error_score=error_score,
                          return_train_score=return_train_score,
                          max_budget=max_budget, budget_on=budget_on,

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -112,10 +112,10 @@ class BaseSuccessiveHalving(CustomBaseSearchCV):
 
         self.max_budget_ = self.max_budget
         if self.max_budget_ == 'auto':
-            if self.budget_on == 'n_samples':
-                self.max_budget_ = X.shape[0]
-            else:
-                self.max_budget_ = 20  # FIXME  # n_candidates * r_min??
+            if not self.budget_on == 'n_samples':
+                raise ValueError(
+                    "max_budget can only be 'auto' if budget_on='n_samples'")
+            self.max_budget_ = X.shape[0]
 
         if self.r_min_ > self.max_budget_:
             raise ValueError(
@@ -348,7 +348,7 @@ class GridSuccessiveHalving(BaseSuccessiveHalving):
         expensive and is not strictly required to select the parameters that
         yield the best generalization performance.
 
-    max_budget : int
+    max_budget : int, optional(default='auto')
         The maximum number of resources that any candidate is allowed to use
         for a given iteration. By default, this is set ``n_samples`` when
         ``budget_on='n_samples'`` (default), else an error is raised.
@@ -649,7 +649,7 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         expensive and is not strictly required to select the parameters that
         yield the best generalization performance.
 
-    max_budget : int
+    max_budget : int, optional(default='auto')
         The maximum number of resources that any candidate is allowed to use
         for a given iteration. By default, this is set ``n_samples`` when
         ``budget_on='n_samples'`` (default), else an error is raised.
@@ -799,7 +799,6 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         the parameter setting for the best model, that gives the highest
         mean score (``search.best_score_``).
 
-    # FIXME really supported?
     scorer_ : function or a dict
         Scorer function used on the held out data to choose the best
         parameters for the model.

--- a/dabl/search.py
+++ b/dabl/search.py
@@ -22,7 +22,6 @@ def _refit_callable(results):
     sorted_indices = np.argsort(results['mean_test_score'])[::-1]
     best_index = next(i for i in sorted_indices
                       if results['iter'][i] == last_iter)
-    raise ValueError("QIPEGNQPEIGNQIPEGN")
     return best_index
 
 
@@ -597,7 +596,6 @@ class RandomSuccessiveHalving(BaseSuccessiveHalving):
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - None, to use the default 3-fold cross validation,
         - integer, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.

--- a/dabl/tests/test_search.py
+++ b/dabl/tests/test_search.py
@@ -223,7 +223,7 @@ def test_budget_on():
     parameters = {'a': [1, 2], 'b': list(range(10))}
     base_estimator = FastClassifier()
     sh = GridSuccessiveHalving(base_estimator, parameters, cv=2,
-                               budget_on='c', ratio=3)
+                               budget_on='c', max_budget=10, ratio=3)
     sh.fit(X, y)
     assert set(sh._r_i_list) == set([1, 3, 9])
     for r_i, params, param_c in zip(sh.cv_results_['r_i'],
@@ -235,7 +235,7 @@ def test_budget_on():
             ValueError,
             match='Cannot budget on parameter 1234 which is not supported '):
         sh = GridSuccessiveHalving(base_estimator, parameters, cv=2,
-                                   budget_on='1234')
+                                   budget_on='1234', max_budget=10)
         sh.fit(X, y)
 
     with pytest.raises(
@@ -244,7 +244,7 @@ def test_budget_on():
                   'searched parameters.'):
         parameters = {'a': [1, 2], 'b': [1, 2], 'c': [1, 3]}
         sh = GridSuccessiveHalving(base_estimator, parameters, cv=2,
-                                   budget_on='c')
+                                   budget_on='c', max_budget=10)
         sh.fit(X, y)
 
 

--- a/examples/plot_successive_halving_iterations.py
+++ b/examples/plot_successive_halving_iterations.py
@@ -41,7 +41,8 @@ mean_scores = results.pivot(index='iter', columns='params_str',
                             values='mean_test_score')
 ax = mean_scores.plot(legend=False, alpha=.6)
 
-labels = ['{}\nn_samples={}'.format(i, rsh._r_i_list[i])
+r_i_list = results.groupby('iter').r_i.unique()
+labels = ['{}\nn_samples={}'.format(i, r_i_list[i])
           for i in range(rsh.n_iterations_)]
 ax.set_xticklabels(labels)
 ax.set_title('Candidate scores over iterations')


### PR DESCRIPTION
Various little things:

- Use stratified subsampling
- `scoring` param cannot accept lists or dicts. This is because when doing multi-metric evaluation, BaseSearchCV requires `refit` to be a string, and we cannot allow this since we need to override it.
- refit only accepts True or False
- raise error if max_budget isn't set when budget_on!=n_samples
- removed f strings