### PR TITLE
DOC fix issue with autosummary with RTD and numpydoc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -313,3 +313,4 @@ sphinx_gallery_conf = {
 def setup(app):
     # a copy button to copy snippet of code from the documentation
     app.add_javascript('js/copybutton.js')
+    app.add_stylesheet("basic.css")


### PR DESCRIPTION
It should solve the issue of missing semicolon and spacing in the API documentation.