### PR TITLE
fix vertical stacking of y_train and y_test.

### DIFF
--- a/dabl/models.py
+++ b/dabl/models.py
@@ -65,7 +65,7 @@ class _BaseSimpleEstimator(_DablBaseEstimator):
         res = []
         for X_train, X_test, y_train, y_test in data_preproc:
             X = np.vstack([X_train, X_test])
-            y = np.hstack([y_train, y_test])
+            y = np.vstack([y_train, y_test])
             train = np.arange(len(X_train))
             test = np.arange(len(X_train), len(X_test) + len(X_train))
             with warnings.catch_warnings():

--- a/dabl/models.py
+++ b/dabl/models.py
@@ -65,7 +65,10 @@ class _BaseSimpleEstimator(_DablBaseEstimator):
         res = []
         for X_train, X_test, y_train, y_test in data_preproc:
             X = np.vstack([X_train, X_test])
-            y = np.vstack([y_train, y_test])
+            if y_train.ndim < 2 and y_test.ndim < 2:
+                y = np.hstack([y_train, y_test])
+            else:
+                y = np.vstack([y_train, y_test])
             train = np.arange(len(X_train))
             test = np.arange(len(X_train), len(X_test) + len(X_train))
             with warnings.catch_warnings():

--- a/dabl/tests/test_models.py
+++ b/dabl/tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+import numpy as np
 
 from sklearn.datasets import load_iris, make_blobs, load_boston, load_digits
 from sklearn.svm import LinearSVC
@@ -131,3 +132,17 @@ def test_model_type_hints(monkeypatch, type_hints, Model):
             # it's in the continuous part
             # same for categorical
             assert col_name in get_columns_by_name(ct, type_hints[col_name])
+
+
+@pytest.mark.parametrize('X, y',
+                         [(pd.DataFrame(np.random.random(10).reshape(-1, 1)),
+                           pd.Series(np.random.random(10))),
+                          (pd.DataFrame(np.random.random(10).reshape(-1, 1)),
+                           pd.DataFrame(np.random.random(10).reshape(-1, 1)))])
+def test_evaluate_score_ndim(X, y):
+    """Test fit() works for both y.ndim == 1 and y.ndim == 2. Two test cases
+    are listed in @pytest.mark.parametrize()
+    """
+    sr = SimpleRegressor(random_state=0)
+    print(f"Data ndim: X: {X.shape}, y: {y.shape}")
+    sr.fit(X, y)


### PR DESCRIPTION
Hi,

I came across the error below when running `SimpleRegressor().fit()`. 

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-35-5cf9595eba37> in <module>
----> 1 reg.fit(x_samples, y_samples)

~/git/dabl/dabl/models.py in fit(self, X, y, target_col)
    339         self._rank_scoring = "r2"
    340 
--> 341         return self._fit(X=X, y=y, target_col=target_col)
    342 
    343 

~/git/dabl/dabl/models.py in _fit(self, X, y, target_col)
    157             set_random_state(est, self.random_state)
    158             scorers, _ = _check_multimetric_scoring(est, self.scoring_)
--> 159             scores = self._evaluate_one(est, data_preproc, scorers)
    160             # make scoring configurable
    161             if scores[rank_scoring] > self.current_best_[rank_scoring]:

~/git/dabl/dabl/models.py in _evaluate_one(self, estimator, data_preproc, scorers)
     71         for X_train, X_test, y_train, y_test in data_preproc:
     72             X = np.vstack([X_train, X_test])
---> 73             y = np.hstack([y_train, y_test])
     74             train = np.arange(len(X_train))
     75             test = np.arange(len(X_train), len(X_test) + len(X_train))

<__array_function__ internals> in hstack(*args, **kwargs)

/usr/anaconda3/lib/python3.7/site-packages/numpy/core/shape_base.py in hstack(tup)
    342         return _nx.concatenate(arrs, 0)
    343     else:
--> 344         return _nx.concatenate(arrs, 1)
    345 
    346 

<__array_function__ internals> in concatenate(*args, **kwargs)

ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 80000 and the array at index 1 has size 20000
```

I think this might be a typo - master version uses `np.hstack()` when I think `np.vstack()` is needed. See code line:

https://github.com/amueller/dabl/blob/2f8f49e740d34dcb52ebc7dadd8bee0630ec67e1/dabl/models.py#L68

Post fixing this issue, `SimpleRegressor().fit()` worked for me. 

Please let me know if anything else is needed for this PR. Happy to do more to bring it over the finishing line.

