### PR TITLE
Add example for class_hists

### DIFF
--- a/dabl/plot/utils.py
+++ b/dabl/plot/utils.py
@@ -444,6 +444,12 @@ def class_hists(data, column, target, bins="auto", ax=None, legend=False):
         Axes to plot into
     legend : boolean
         Whether to create a legend.
+
+    Examples
+    --------
+    >>> from dabl.datasets import load_adult
+    >>> data = load_adult()
+    >>> class_hists(data, "age", "gender", legend=True)
     """
     col_data = data[column].dropna()
 

--- a/examples/plot/plot_class_hists.py
+++ b/examples/plot/plot_class_hists.py
@@ -2,11 +2,12 @@
 Class Histogram Example
 ==========================================
 """
-# sphinx_gallery_thumbnail_number = 1
 import matplotlib.pyplot as plt
 from dabl.datasets import load_adult
 from dabl.plot import class_hists
 
 data = load_adult()
+
+# Plots the histogram of age per gender
 class_hists(data, "age", "gender", legend=True)
 plt.show()

--- a/examples/plot/plot_class_hists.py
+++ b/examples/plot/plot_class_hists.py
@@ -1,0 +1,12 @@
+"""
+Class Histogram Example
+==========================================
+"""
+# sphinx_gallery_thumbnail_number = 1
+import matplotlib.pyplot as plt
+from dabl.datasets import load_adult
+from dabl.plot import class_hists
+
+data = load_adult()
+class_hists(data, "age", "gender", legend=True)
+plt.show()


### PR DESCRIPTION
This issue fixes #165. The example uses the `adult` dataset provided by the package. There is only one plot that looks at the histogram of age given gender.

The same example was added to the docstrings of `class_hists`.