### PR TITLE
fix one-hot encoding in EasyPreprocessor

### DIFF
--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -537,10 +537,12 @@ class EasyPreprocessor(BaseEstimator, TransformerMixin):
         # check for missing values
         # scale etc
         steps_categorical = []
+        categorical_cols = X.columns[types.categorical]
+        X[categorical_cols] = X[categorical_cols].replace(to_replace='',
+                                                          value=np.NaN)
         if (self.force_imputation
                 or X.loc[:, types.categorical].isna().any(axis=None)):
-            steps_categorical.append(
-                SimpleImputer(strategy='most_frequent', add_indicator=True))
+            steps_categorical.append(SimpleImputer(strategy='most_frequent'))
         steps_categorical.append(
             OneHotEncoder(categories='auto', handle_unknown='ignore',
                           sparse=False))
@@ -578,7 +580,7 @@ class EasyPreprocessor(BaseEstimator, TransformerMixin):
             transformer_cols.append(('dirty_float',
                                      pipe_dirty_float, types['dirty_float']))
 
-        if not len(transformer_cols):
+        if not transformer_cols:
             raise ValueError("No feature columns found")
         self.ct_ = ColumnTransformer(transformer_cols, sparse_threshold=.1)
 

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -267,9 +267,8 @@ def test_type_hints(type_hints):
 
 def test_simple_preprocessor():
     sp = EasyPreprocessor()
-    sp.fit(X_cat)
-    trans = sp.transform(X_cat)
-    assert trans.shape == (3, 7)  # FIXME should be 6?
+    trans = sp.fit_transform(X_cat)
+    assert trans.shape == (3, 6)
 
     iris = load_iris()
     sp = EasyPreprocessor()


### PR DESCRIPTION
- Replace empty strings with `numpy.NaN` to treat them as missing values
- Disable `MissingIndicator` in a categorical `SimpleImputer`