### PR TITLE
Treat nans in reg targets

### DIFF
--- a/dabl/plot/supervised.py
+++ b/dabl/plot/supervised.py
@@ -24,6 +24,7 @@ from .utils import (_check_X_target_col, _get_n_top, _make_subplots,
                     class_hists, discrete_scatter, mosaic_plot,
                     _find_inliers, pairplot, _get_scatter_alpha,
                     _get_scatter_size)
+from warnings import warn
 
 
 def plot_regression_continuous(X, target_col, types=None,
@@ -51,6 +52,11 @@ def plot_regression_continuous(X, target_col, types=None,
         Whether to drop outliers when plotting.
     """
     types = _check_X_target_col(X, target_col, types, task="regression")
+
+    if np.isnan(X[target_col]).any():
+        X = X.dropna(subset=[target_col])
+        warn("Missing values in target_col have been removed for regression",
+             UserWarning)
 
     features = X.loc[:, types.continuous]
     if target_col in features.columns:
@@ -110,6 +116,12 @@ def plot_regression_categorical(X, target_col, types=None, **kwargs):
         types.
     """
     types = _check_X_target_col(X, target_col, types, task="regression")
+
+    # drop nans from target column
+    if np.isnan(X[target_col]).any():
+        X = X.dropna(subset=[target_col])
+        warn("Missing values in target_col have been removed for regression",
+             UserWarning)
 
     if types is None:
         types = detect_types(X)

--- a/dabl/plot/tests/test_supervised.py
+++ b/dabl/plot/tests/test_supervised.py
@@ -248,7 +248,8 @@ def test_na_vals_reg_plot_raise_warning():
     scatter_size = _get_scatter_size('auto', X['target_col'])
     with pytest.warns(UserWarning, match="Missing values in target_col have "
                                          "been removed for regression"):
-        plot_regression_continuous(X, 'target_col', scatter_alpha=scatter_alpha,
+        plot_regression_continuous(X, 'target_col',
+                                   scatter_alpha=scatter_alpha,
                                    scatter_size=scatter_size)
     with pytest.warns(UserWarning, match="Missing values in target_col have "
                                          "been removed for regression"):

--- a/dabl/plot/tests/test_supervised.py
+++ b/dabl/plot/tests/test_supervised.py
@@ -248,6 +248,9 @@ def test_na_vals_reg_plot_raise_warning():
     scatter_size = _get_scatter_size('auto', X['target_col'])
     with pytest.warns(UserWarning, match="Missing values in target_col have "
                                          "been removed for regression"):
+        plot(X, 'target_col')
+    with pytest.warns(UserWarning, match="Missing values in target_col have "
+                                         "been removed for regression"):
         plot_regression_continuous(X, 'target_col',
                                    scatter_alpha=scatter_alpha,
                                    scatter_size=scatter_size)

--- a/dabl/plot/tests/test_supervised.py
+++ b/dabl/plot/tests/test_supervised.py
@@ -6,13 +6,13 @@ import matplotlib.pyplot as plt
 import itertools
 
 from sklearn.datasets import (make_regression, make_blobs, load_digits,
-                              fetch_openml)
+                              fetch_openml, load_diabetes)
 from sklearn.preprocessing import KBinsDiscretizer
 from dabl.preprocessing import clean, detect_types, guess_ordinal
 from dabl.plot.supervised import (
     plot, plot_classification_categorical,
     plot_classification_continuous, plot_regression_categorical,
-    plot_regression_continuous)
+    plot_regression_continuous, _get_scatter_alpha, _get_scatter_size)
 from dabl.utils import data_df_from_bunch
 
 
@@ -237,3 +237,21 @@ def test_plot_string_target():
     y[y == 2] = 'c'
     data['target'] = y
     plot(data, target_col='target')
+
+
+def test_na_vals_reg_plot_raise_warning():
+    X, y = load_diabetes(return_X_y=True)
+    X = pd.DataFrame(X)
+    y[::50] = np.NaN
+    X['target_col'] = y
+    scatter_alpha = _get_scatter_alpha('auto', X['target_col'])
+    scatter_size = _get_scatter_size('auto', X['target_col'])
+    with pytest.warns(UserWarning, match="Missing values in target_col have "
+                                         "been removed for regression"):
+        plot_regression_continuous(X, 'target_col', scatter_alpha=scatter_alpha,
+                                   scatter_size=scatter_size)
+    with pytest.warns(UserWarning, match="Missing values in target_col have "
+                                         "been removed for regression"):
+        plot_regression_categorical(X, 'target_col',
+                                    scatter_alpha=scatter_alpha,
+                                    scatter_size=scatter_size)


### PR DESCRIPTION
This PR should fix #210.

an alternative to this could be a private _method to check the target column and drop nan values. This method will be private to plot in utils.py and called from supervised.py wherever required.