### PR TITLE
fix EasyProcessor get_feature_names

### DIFF
--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -604,8 +604,14 @@ class EasyPreprocessor(BaseEstimator, TransformerMixin):
             elif name == 'categorical':
                 # this is the categorical pipe, extract one hot encoder
                 ohe = trans.steps[-1][1]
-                # FIXME that is really strange?!
-                ohe_cols = self.columns_[self.columns_.map(cols)]
+                imputer = trans.steps[0][1]
+
+                ohe_cols = cols[cols].index
+                added_cols = ohe_cols[imputer.indicator_.features_].map(
+                    lambda x: '{}_imputed'.format(x))
+                ohe_cols = ohe_cols.to_list()
+                ohe_cols.extend(added_cols)
+
                 feature_names.extend(ohe.get_feature_names(ohe_cols))
             elif name == "remainder":
                 assert trans == "drop"

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -360,3 +360,14 @@ def test_easy_preprocessor_transform():
     pipe.fit(X_train, y_train)
     pipe.predict(X_train)
     pipe.predict(X_val)
+
+
+def test_simple_preprocessor_imputed_features():
+    # Issue: 211
+
+    data = pd.DataFrame({'A': [0, 1, 2, 1, np.NaN]}, dtype=int)
+    types = detect_types(data, type_hints={'A': 'categorical'})
+
+    ep = EasyPreprocessor(types=types)
+    ep.fit(data)
+    ep.get_feature_names()

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -376,4 +376,6 @@ def test_simple_preprocessor_imputed_features():
 
     ep = EasyPreprocessor(types=types)
     ep.fit(data)
-    ep.get_feature_names()
+
+    expected_names = ['A_0', 'A_1', 'A_2', 'A_imputed_False', 'A_imputed_True']
+    assert ep.get_feature_names() == expected_names


### PR DESCRIPTION
Fix #211 

Reason: SimpleImputer adds extra columns for features having NaN values. This behavior breaks OneHotEncoder get_feature_names call.