### PR TITLE
discard regression target values that cannot be converted to float

### DIFF
--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -435,7 +435,8 @@ def clean(X, type_hints=None, return_types=False,
         types = pd.concat([types[~types.dirty_float], types_df])
 
         # discard dirty float targets that cant be converted to float
-        if np.isnan(X["{}_dabl_continuous".format(target_col)]).any():
+        if target_col is not None and np.isnan(X["{}_dabl_continuous".format(\
+                target_col)]).any():
             warn("Discarding dirty_float targets that cannot be converted "
                  "to float.", UserWarning)
             X = X.dropna(subset=["{}_dabl_continuous".format(target_col)])

--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -435,7 +435,7 @@ def clean(X, type_hints=None, return_types=False,
         types = pd.concat([types[~types.dirty_float], types_df])
 
         # discard dirty float targets that cant be converted to float
-        if target_col is not None and np.isnan(X["{}_dabl_continuous".format(\
+        if target_col is not None and np.isnan(X["{}_dabl_continuous".format(
                 target_col)]).any():
             warn("Discarding dirty_float targets that cannot be converted "
                  "to float.", UserWarning)

--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -417,8 +417,8 @@ def clean(X, type_hints=None, return_types=False,
     if not X.index.is_unique:
         warn("Index not unique, resetting index!", UserWarning)
         X = X.reset_index(drop=True)
-    types = detect_types(X, type_hints=type_hints, verbose=verbose,
-                         target_col=target_col)
+    types_p = types = detect_types(X, type_hints=type_hints, verbose=verbose,
+                                   target_col=target_col)
     # drop useless columns
     X = X.loc[:, ~types.useless].copy()
     types = types[~types.useless]
@@ -435,8 +435,8 @@ def clean(X, type_hints=None, return_types=False,
         types = pd.concat([types[~types.dirty_float], types_df])
 
         # discard dirty float targets that cant be converted to float
-        if target_col is not None and np.isnan(X["{}_dabl_continuous".format(
-                target_col)]).any():
+        if target_col is not None and types_p['dirty_float'][target_col] and\
+                np.isnan(X["{}_dabl_continuous".format(target_col)]).any():
             warn("Discarding dirty_float targets that cannot be converted "
                  "to float.", UserWarning)
             X = X.dropna(subset=["{}_dabl_continuous".format(target_col)])

--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -433,6 +433,17 @@ def clean(X, type_hints=None, return_types=False,
         # we should know what these are but maybe running this again is fine?
         types_df = detect_types(X_df)
         types = pd.concat([types[~types.dirty_float], types_df])
+
+        # discard dirty float targets that cant be converted to float
+        if np.isnan(X["{}_dabl_continuous".format(target_col)]).any():
+            warn("Discarding dirty_float targets that cannot be converted "
+                 "to float.", UserWarning)
+            X = X.dropna(subset=["{}_dabl_continuous".format(target_col)])
+            X = X.rename(columns={"{}_dabl_continuous".format(
+                target_col): "{}".format(target_col)})
+            types = types.rename(index={"{}_dabl_continuous".format(
+                target_col): "{}".format(target_col)})
+
     # deal with low cardinality ints
     # TODO ?
     # ensure that the indicator variables are also marked as categorical

--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -435,8 +435,7 @@ def clean(X, type_hints=None, return_types=False,
         types = pd.concat([types[~types.dirty_float], types_df])
 
         # discard dirty float targets that cant be converted to float
-        if target_col is not None and types_p['dirty_float'][target_col] and\
-                np.isnan(X["{}_dabl_continuous".format(target_col)]).any():
+        if target_col is not None and types_p['dirty_float'][target_col]:
             warn("Discarding dirty_float targets that cannot be converted "
                  "to float.", UserWarning)
             X = X.dropna(subset=["{}_dabl_continuous".format(target_col)])

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -370,10 +370,16 @@ def test_easy_preprocessor_transform():
 
 
 def test_dirty_float_target_regression():
+    titanic_data = load_titanic()
     data = pd.DataFrame({'one': np.repeat(np.arange(50), 2)})
     dirty = make_dirty_float()
     data['target'] = dirty
-    plot(data, target_col="target")
     with pytest.warns(UserWarning, match="Discarding dirty_float targets that "
                                          "cannot be converted to float."):
         clean(data, target_col="target")
+    with pytest.warns(UserWarning, match="Discarding dirty_float targets that "
+                                         "cannot be converted to float."):
+        plot(data, target_col="target")
+
+    # check if works for non dirty_float targets
+    plot(titanic_data, 'survived')

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -15,6 +15,7 @@ from dabl.preprocessing import (detect_types, EasyPreprocessor,
                                 _float_matching)
 from dabl.utils import data_df_from_bunch
 from dabl.datasets import load_titanic
+from dabl import plot
 
 
 X_cat = pd.DataFrame({'a': ['b', 'c', 'b'],
@@ -366,3 +367,13 @@ def test_easy_preprocessor_transform():
     pipe.fit(X_train, y_train)
     pipe.predict(X_train)
     pipe.predict(X_val)
+
+
+def test_dirty_float_target_regression():
+    data = pd.DataFrame({'one': np.repeat(np.arange(50), 2)})
+    dirty = make_dirty_float()
+    data['target'] = dirty
+    plot(data, target_col="target")
+    with pytest.warns(UserWarning, match="Discarding dirty_float targets that "
+                                         "cannot be converted to float."):
+        clean(data, target_col="target")


### PR DESCRIPTION
this should fix #212 
an alternative way of doing this could be to pass 'target_col' to `DirtyFloatCleaner` and remove the values that could not be converted before the renaming takes place. This will remove the need to rename columns and convert types. Let me know if it needs to be done this way.