### PR TITLE
Drop outliers in target column in plot_regression_continuous

### DIFF
--- a/dabl/plot/supervised.py
+++ b/dabl/plot/supervised.py
@@ -58,6 +58,10 @@ def plot_regression_continuous(X, target_col, types=None,
         warn("Missing values in target_col have been removed for regression",
              UserWarning)
 
+    if drop_outliers:
+        inliers = _find_inliers(X.loc[:, target_col])
+        X = X.loc[inliers, :]
+
     features = X.loc[:, types.continuous]
     if target_col in features.columns:
         features = features.drop(target_col, axis=1)

--- a/dabl/plot/tests/test_supervised.py
+++ b/dabl/plot/tests/test_supervised.py
@@ -259,3 +259,26 @@ def test_na_vals_reg_plot_raise_warning():
         plot_regression_categorical(X, 'target_col',
                                     scatter_alpha=scatter_alpha,
                                     scatter_size=scatter_size)
+
+
+def test_plot_regression_continuous_with_target_outliers():
+    df = pd.DataFrame(
+        data={
+            "feature": np.random.randint(low=1, high=100, size=200),
+            # target values are bound between 50 and 100
+            "target": np.random.randint(low=50, high=100, size=200)
+            }
+    )
+    scatter_alpha = _get_scatter_alpha('auto', df['target'])
+    scatter_size = _get_scatter_size('auto', df['target'])
+    # append single outlier record with target value 0
+    df = df.append({"feature": 50, "target": 0}, ignore_index=True)
+
+    with pytest.warns(
+        UserWarning,
+        match="Dropped 1 outliers in column target."
+    ):
+        plot_regression_continuous(df, 'target',
+                                   scatter_alpha=scatter_alpha,
+                                   scatter_size=scatter_size
+                                   )


### PR DESCRIPTION
This pull request adds a step to drop outliers in the target column for regression plots in order to improve the usability of such plots in case of outliers in the target column. This is done by simply calling `_find_inliers`  on the target column as it is already done per default for features.

The plot for the dataset `topo_2_1` mentioned in #214 with the menioned fix looks the following:
![example_plot_fix](https://user-images.githubusercontent.com/23054770/84567770-26b1f180-ad7b-11ea-9582-3fb684c2c3e9.png)