### PR TITLE
Max cat fix

### DIFF
--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -219,7 +219,15 @@ _OBJECT_TYPES = ['string', 'bytes', 'mixed', 'mixed-integer']
 _CATEGORICAL_TYPES = ['categorical', 'boolean']
 
 
-def _type_detection_int(series, max_int_cardinality='auto'):
+def _get_max_cat_cardinality(n_samples, max_cat_cardinality="auto"):
+    if max_cat_cardinality == "auto":
+        max_cat_cardinality = max(42, n_samples / 100)
+        if n_samples <= 42:
+            # this is pretty hacky
+            max_cat_cardinality = n_samples // 2
+    return max_cat_cardinality
+
+def _type_detection_int(series, max_cat_cardinality='auto'):
     n_distinct_values = series.nunique()
     if n_distinct_values == len(series):
         # could be an index
@@ -231,7 +239,7 @@ def _type_detection_int(series, max_int_cardinality='auto'):
             if (series == np.arange(1, len(series) + 1)).all():
                 # definitely an index
                 return 'useless'
-    if n_distinct_values > max_int_cardinality:
+    if n_distinct_values > _get_max_cat_cardinality(len(series), max_cat_cardinality):
         return 'continuous'
     elif n_distinct_values <= 5:
         # weird hack / edge case
@@ -240,31 +248,31 @@ def _type_detection_int(series, max_int_cardinality='auto'):
         return 'low_card_int'
 
 
-def _type_detection_float(series, max_int_cardinality='auto'):
+def _type_detection_float(series, max_cat_cardinality='auto'):
     if _float_col_is_int(series):
         return _type_detection_int(
-            series, max_int_cardinality=max_int_cardinality)
+            series, max_cat_cardinality=max_cat_cardinality)
     return 'continuous'
 
 
 def _type_detection_object(series, *, dirty_float_threshold,
-                           max_int_cardinality='auto'):
+                           max_cat_cardinality='auto'):
     clean_float_string, dirty_float = _find_string_floats(
             series, dirty_float_threshold)
     if dirty_float.any():
         return 'dirty_float'
     elif clean_float_string.any():
         return _type_detection_float(
-            series.astype(float), max_int_cardinality=max_int_cardinality)
+            series.astype(float), max_cat_cardinality=max_cat_cardinality)
     if _string_is_date(series):
         return 'date'
-    if series.nunique() <= max_int_cardinality:
+    if series.nunique() <= _get_max_cat_cardinality(len(series), max_cat_cardinality):
         return 'categorical'
     return "free_string"
 
 
 def detect_type_series(series, *, dirty_float_threshold=0.9,
-                       max_int_cardinality='auto',
+                       max_cat_cardinality='auto',
                        near_constant_threshold=0.95, target_col=None):
     n_distinct_values = series.nunique()
     if series.isna().mean() > 0.99:
@@ -290,20 +298,20 @@ def detect_type_series(series, *, dirty_float_threshold=0.9,
         return 'categorical'
     elif inferred_type in _FLOAT_TYPES:
         return _type_detection_float(
-            series, max_int_cardinality=max_int_cardinality)
+            series, max_cat_cardinality=max_cat_cardinality)
     elif inferred_type in _INTEGER_TYPES:
         return _type_detection_int(
-            series, max_int_cardinality=max_int_cardinality)
+            series, max_cat_cardinality=max_cat_cardinality)
     elif inferred_type in _OBJECT_TYPES:
         return _type_detection_object(
-            series, max_int_cardinality=max_int_cardinality,
+            series, max_cat_cardinality=max_cat_cardinality,
             dirty_float_threshold=dirty_float_threshold
         )
     else:
         raise ValueError("WEEEEEIIIRRD")
 
 
-def detect_types(X, type_hints=None, max_int_cardinality='auto',
+def detect_types(X, type_hints=None, max_cat_cardinality='auto',
                  dirty_float_threshold=.9,
                  near_constant_threshold=0.95, target_col=None,
                  verbose=0):
@@ -329,11 +337,9 @@ def detect_types(X, type_hints=None, max_int_cardinality='auto',
     X : dataframe
         input
 
-    max_int_cardinality: int or 'auto', default='auto'
-        Maximum number of distinct integers for an integer column
+    max_cat_cardinality: int or 'auto', default='auto'
+        Maximum number of distinct integer or string values for a column
         to be considered categorical. 'auto' is ``max(42, n_samples/100)``.
-        Integers are also always considered as continuous variables.
-        FIXME not true any more?
 
     dirty_float_threshold : float, default=.9
         The fraction of floats required in a dirty continuous
@@ -368,14 +374,9 @@ def detect_types(X, type_hints=None, max_int_cardinality='auto',
         type_hints = dict()
 
     n_samples, _ = X.shape
-    if max_int_cardinality == "auto":
-        max_int_cardinality = max(42, n_samples / 100)
-        if n_samples <= 42:
-            # this is pretty hacky
-            max_int_cardinality = n_samples // 2
 
     types_series = X.apply(lambda col: detect_type_series(
-        col, max_int_cardinality=max_int_cardinality,
+        col, max_cat_cardinality=max_cat_cardinality,
         near_constant_threshold=near_constant_threshold,
         target_col=target_col, dirty_float_threshold=dirty_float_threshold))
 

--- a/dabl/preprocessing.py
+++ b/dabl/preprocessing.py
@@ -227,6 +227,7 @@ def _get_max_cat_cardinality(n_samples, max_cat_cardinality="auto"):
             max_cat_cardinality = n_samples // 2
     return max_cat_cardinality
 
+
 def _type_detection_int(series, max_cat_cardinality='auto'):
     n_distinct_values = series.nunique()
     if n_distinct_values == len(series):
@@ -239,7 +240,8 @@ def _type_detection_int(series, max_cat_cardinality='auto'):
             if (series == np.arange(1, len(series) + 1)).all():
                 # definitely an index
                 return 'useless'
-    if n_distinct_values > _get_max_cat_cardinality(len(series), max_cat_cardinality):
+    if n_distinct_values > _get_max_cat_cardinality(len(series),
+                                                    max_cat_cardinality):
         return 'continuous'
     elif n_distinct_values <= 5:
         # weird hack / edge case
@@ -266,7 +268,8 @@ def _type_detection_object(series, *, dirty_float_threshold,
             series.astype(float), max_cat_cardinality=max_cat_cardinality)
     if _string_is_date(series):
         return 'date'
-    if series.nunique() <= _get_max_cat_cardinality(len(series), max_cat_cardinality):
+    if series.nunique() <= _get_max_cat_cardinality(len(series),
+                                                    max_cat_cardinality):
         return 'categorical'
     return "free_string"
 

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -13,7 +13,7 @@ from sklearn.linear_model import LogisticRegression
 
 from dabl.preprocessing import (detect_types, EasyPreprocessor,
                                 DirtyFloatCleaner, clean, _FLOAT_REGEX,
-                                _float_matching)
+                                _float_matching, detect_type_series)
 from dabl.utils import data_df_from_bunch
 from dabl.datasets import load_titanic
 from dabl import plot
@@ -188,8 +188,8 @@ def test_detect_types():
     assert res_iris.continuous.sum() == 4
 
     for col in df_all.columns:
-        t = detect_types_series(df_all[col])
-        assert t = types['col']
+        t = detect_type_series(df_all[col])
+        assert t == types[col]
 
 def test_detect_low_cardinality_int():
     df_all = pd.DataFrame(

--- a/dabl/tests/test_preprocessing.py
+++ b/dabl/tests/test_preprocessing.py
@@ -187,6 +187,9 @@ def test_detect_types():
     assert (res_iris.sum(axis=1) == 1).all()
     assert res_iris.continuous.sum() == 4
 
+    for col in df_all.columns:
+        t = detect_types_series(df_all[col])
+        assert t = types['col']
 
 def test_detect_low_cardinality_int():
     df_all = pd.DataFrame(


### PR DESCRIPTION
fixes not parsing the max_int_cardinality in `detect_type_series` and also renames it to `max_cat_cardinality` as it's also used for strings.