### PR TITLE
Add example of partial dependence plot for regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Stay Tuned!
 
 ## Related packages
 
-## Lux
-[Lux](https://github.com/lux-org/lux) is an awesome project for easy interactive visualization of pandas dataframes within notebooks.
-
 ### Pandas Profiling
 [Pandas Profiling](https://github.com/pandas-profiling/pandas-profiling) can
 provide a thorough summary of the data in only a single line of code. Using the

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -4,16 +4,15 @@ Diabetes Dataset Visualization
 ==========================================
 """
 import pandas as pd
-from sklearn import datasets           
+from sklearn import datasets
 from sklearn.inspection import plot_partial_dependence
 from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 diabetes = datasets.load_diabetes()
 
-X = pd.DataFrame(diabetes.data, columns= diabetes.feature_names)
+X = pd.DataFrame(diabetes.data, columns = diabetes.feature_names)
 y = diabetes.target
-
 
 est = HistGradientBoostingRegressor()
 est.fit(X, y)
@@ -22,8 +21,6 @@ for i in range(0, 10):
   display = plot_partial_dependence(est, X, [i])
 
 for i in range(0, 10):
-    for j in range(0, 10):
-        if(i < j):
-            display = plot_partial_dependence(est, X, [(i, j)])
-
-
+  for j in range(0, 10):
+    if(i < j):
+      display = plot_partial_dependence(est, X, [(i, j)])

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -11,17 +11,17 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 diabetes = datasets.load_diabetes()
 
-X= pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
+X= pd.DataFrame(diabetes.data, columns= diabetes.feature_names)
 y=diabetes.target
 
 
 est= HistGradientBoostingRegressor()
-est.fit(X,y)
+est.fit(X, y)
 
 for i in range(0,10):
-  display=plot_partial_dependence(est, X, [i])
+  display = plot_partial_dependence(est, X, [i])
 
-for i in range(0,10):
-    for j in range(0,10):
-        if(i<j):
-            display=plot_partial_dependence(est, X, [(i,j)])
+for i in range(0, 10):
+    for j in range(0, 10):
+        if(i < j):
+            display = plot_partial_dependence(est, X, [(i, j)])

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -1,26 +1,27 @@
+
 """
 Diabetes Dataset Visualization
 ==========================================
 """
-               
 import pandas as pd
-import matplotlib.pyplot as plt 
-from sklearn.tree import DecisionTreeRegressor
+from sklearn import datasets           
 from sklearn.inspection import plot_partial_dependence
-from sklearn.ensemble import GradientBoostingClassifier
-from sklearn import datasets
+from sklearn.experimental import enable_hist_gradient_boosting
+from sklearn.ensemble import HistGradientBoostingRegressor
 
-diabetes = datasets.load_diabetes
+diabetes = datasets.load_diabetes()
 
 X= pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
-y=pd.DataFrame(diabetes.target)
+y=diabetes.target
 
-tree = DecisionTreeRegressor()
-tree.fit(X, y)
-tree_disp = plot_partial_dependence(tree, X, [0,1,2,3,4,5,6,7,8,9])
-#clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0, max_depth=1, random_state=0).fit(X, y)
-#features = [(0,1), (0,2), (0,3), (0,4), (0,5), (0,6), (0,7), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (2,3), (2,4), (2,5), (2,6), (2,7), (3,4), (3,5), (3,6), (3,7), (4,5), (4,6), (4,7), (5,6), (5,7), (6,7) ]
-#features = [0,1]
-#plot_partial_dependence(clf, X, features) 
-#plt.tight_layout()
-plt.show()
+
+est= HistGradientBoostingRegressor()
+est.fit(X,y)
+
+for i in range(0,10):
+  display=plot_partial_dependence(est, X, [i])
+
+for i in range(0,10):
+    for j in range(0,10):
+        if(i<j):
+            display=plot_partial_dependence(est, X, [(i,j)])

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -11,17 +11,19 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 diabetes = datasets.load_diabetes()
 
-X= pd.DataFrame(diabetes.data, columns= diabetes.feature_names)
-y=diabetes.target
+X = pd.DataFrame(diabetes.data, columns= diabetes.feature_names)
+y = diabetes.target
 
 
-est= HistGradientBoostingRegressor()
+est = HistGradientBoostingRegressor()
 est.fit(X, y)
 
-for i in range(0,10):
+for i in range(0, 10):
   display = plot_partial_dependence(est, X, [i])
 
 for i in range(0, 10):
     for j in range(0, 10):
         if(i < j):
             display = plot_partial_dependence(est, X, [(i, j)])
+
+

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -1,0 +1,26 @@
+"""
+Diabetes Dataset Visualization
+==========================================
+"""
+               
+import pandas as pd
+import matplotlib.pyplot as plt 
+from sklearn.tree import DecisionTreeRegressor
+from sklearn.inspection import plot_partial_dependence
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn import datasets
+
+diabetes = datasets.load_diabetes
+
+X= pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
+y=pd.DataFrame(diabetes.target)
+
+tree = DecisionTreeRegressor()
+tree.fit(X, y)
+tree_disp = plot_partial_dependence(tree, X, [0,1,2,3,4,5,6,7,8,9])
+#clf = GradientBoostingClassifier(n_estimators=100, learning_rate=1.0, max_depth=1, random_state=0).fit(X, y)
+#features = [(0,1), (0,2), (0,3), (0,4), (0,5), (0,6), (0,7), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (2,3), (2,4), (2,5), (2,6), (2,7), (3,4), (3,5), (3,6), (3,7), (4,5), (4,6), (4,7), (5,6), (5,7), (6,7) ]
+#features = [0,1]
+#plot_partial_dependence(clf, X, features) 
+#plt.tight_layout()
+plt.show()

--- a/examples/plot/plot_diabetes.py
+++ b/examples/plot/plot_diabetes.py
@@ -9,18 +9,19 @@ from sklearn.inspection import plot_partial_dependence
 from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingRegressor
 
-diabetes = datasets.load_diabetes()
+diabetes= datasets.load_diabetes()
 
-X = pd.DataFrame(diabetes.data, columns = diabetes.feature_names)
-y = diabetes.target
+X= pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
+y= diabetes.target
 
-est = HistGradientBoostingRegressor()
+enable_hist_gradient_boosting
+est= HistGradientBoostingRegressor()
 est.fit(X, y)
 
 for i in range(0, 10):
-  display = plot_partial_dependence(est, X, [i])
+  display= plot_partial_dependence(est, X, [i])
 
 for i in range(0, 10):
   for j in range(0, 10):
     if(i < j):
-      display = plot_partial_dependence(est, X, [(i, j)])
+      display= plot_partial_dependence(est, X, [(i, j)])


### PR DESCRIPTION
This issue fixes #208. The example uses the diabetes dataset provided by the sklearn. It plots the partial dependency using HistGradientBoosting.