### PR TITLE
Have select subplots share x-/y-axis where appropriate.

### DIFF
--- a/dabl/plot/supervised.py
+++ b/dabl/plot/supervised.py
@@ -126,7 +126,7 @@ def plot_regression_continuous(X, *, target_col, types=None,
     else:
         best_categorical = []
 
-    fig, axes = _make_subplots(n_plots=len(top_k))
+    fig, axes = _make_subplots(n_plots=len(top_k), sharey=True)
 
     # FIXME this could be a function or maybe using seaborn
     plt.suptitle("Continuous Feature vs Target")
@@ -208,7 +208,7 @@ def plot_regression_categorical(
 
     # large number of categories -> taller plot
     row_height = 3 if X.nunique().max() <= 5 else 5
-    fig, axes = _make_subplots(n_plots=show_top, row_height=row_height)
+    fig, axes = _make_subplots(n_plots=show_top, row_height=row_height, sharex=True)
     plt.suptitle("Categorical Feature vs Target")
     for i, (col_ind, ax) in enumerate(zip(top_k, axes.ravel())):
         col = features.columns[i]

--- a/dabl/plot/utils.py
+++ b/dabl/plot/utils.py
@@ -328,13 +328,14 @@ def _fill_missing_categorical(X):
     return X
 
 
-def _make_subplots(n_plots, max_cols=5, row_height=3):
+def _make_subplots(n_plots, max_cols=5, row_height=3, sharex=False, sharey=False):
     """Create a harmonious subplot grid.
     """
     n_rows, n_cols = find_pretty_grid(n_plots, max_cols=max_cols)
     fig, axes = plt.subplots(n_rows, n_cols,
                              figsize=(4 * n_cols, row_height * n_rows),
-                             constrained_layout=True)
+                             constrained_layout=True,
+                             sharex=sharex, sharey=sharey)
     # we don't want ravel to fail, this is awkward!
     axes = np.atleast_2d(axes)
     return fig, axes


### PR DESCRIPTION
Hi @amueller - Following up on our chat after your talk at ODSC. Here's one of the small tweaks I mentioned to improve viz aesthetics.

- Added `sharex` and `sharey` arguments to the `_make_subplots()` utility function to pass down to matplotlib when creating the `Axes`
- Have the "Categorical Feature vs. Target" plot share the x-axis across subplots
- Have "Continuous Feature vs. Target" plot share the y-axis across subplots:
<img width="714" alt="Screen Shot 2022-11-20 at 2 58 28 PM" src="https://user-images.githubusercontent.com/24376333/202923328-05e88dd6-b4f6-4209-ba74-6b59f27cd255.png">
