### PR TITLE
Tick formatting

### DIFF
--- a/dabl/plot/supervised.py
+++ b/dabl/plot/supervised.py
@@ -23,7 +23,7 @@ from .utils import (_check_X_target_col, _get_n_top, _make_subplots,
                     class_hists, discrete_scatter, mosaic_plot,
                     _find_inliers, pairplot, _get_scatter_alpha,
                     _get_scatter_size, _find_categorical_for_regression,
-                    _prune_categories)
+                    _prune_categories, _apply_eng_formatter)
 from .sankey import plot_sankey
 
 from warnings import warn
@@ -148,6 +148,7 @@ def plot_regression_continuous(X, *, target_col, types=None,
                          s=scatter_size, ax=ax, legend=True, **kwargs)
         ax.set_xlabel(col_name)
         ax.set_title("F={:.2E}".format(correlations[col]))
+        _apply_eng_formatter(ax, which="y")
 
     for j in range(i + 1, axes.size):
         # turn off axis if we didn't fill last row
@@ -219,6 +220,7 @@ def plot_regression_categorical(
         ax.set_title("F={:.2E}".format(f[col_ind]))
         # shorten long ticks and labels
         _short_tick_names(ax, label_length=row_height * 12)
+        _apply_eng_formatter(ax, which="x")
 
     for j in range(i + 1, axes.size):
         # turn off axis if we didn't fill last row
@@ -299,6 +301,9 @@ def plot_classification_continuous(
         plt.suptitle(title, y=1.02)
 
         fig = plt.gcf()
+        for ax in fig.axes:
+            _apply_eng_formatter(ax, which="x")
+            _apply_eng_formatter(ax, which="y")
     else:
         # univariate plots
         f = _plot_univariate_classification(features, features_imp, target,
@@ -652,10 +657,12 @@ def plot(X, y=None, target_col=None, type_hints=None, scatter_alpha='auto',
                      UserWarning)
                 X = X.loc[inliers, :]
         _, ax = plt.subplots()
-        plt.hist(X[target_col], bins='auto')
-        plt.xlabel(_shortname(target_col))
-        plt.ylabel("frequency")
-        plt.title("Target distribution")
+        ax.hist(X[target_col], bins='auto')
+        ax.set(xlabel=_shortname(target_col),
+               ylabel="frequency",
+               title="Target distribution")
+        _apply_eng_formatter(ax, which="x")
+        _apply_eng_formatter(ax, which="y")
         res.append(ax)
         scatter_alpha = _get_scatter_alpha(scatter_alpha, X[target_col])
         scatter_size = _get_scatter_size(scatter_size, X[target_col])
@@ -681,7 +688,8 @@ def plot(X, y=None, target_col=None, type_hints=None, scatter_alpha='auto',
         # but melt destroys it:
         # https://github.com/pandas-dev/pandas/issues/15853
         melted['class'] = melted['class'].astype('category')
-        sns.barplot(y='class', x='count', data=melted)
+        ax = sns.barplot(y='class', x='count', data=melted)
+        _apply_eng_formatter(ax, which="x")
         plt.title("Target distribution")
         if len(counts) >= 50:
             print("Not plotting anything for 50 classes or more."

--- a/dabl/plot/utils.py
+++ b/dabl/plot/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle, Patch
+from matplotlib.ticker import EngFormatter
 from seaborn.utils import despine
 
 
@@ -739,3 +740,25 @@ def plot_multiclass_roc_curve(estimator, X_val, y_val):
         ax.set_xlabel("False Positive Rate")
         ax.set_ylabel("True Positive Rate (recall)")
         ax.set_title("ROC curve for class {}".format(c))
+
+def _apply_eng_formatter(ax, which):
+    """Apply engineering format to axis ticks.
+
+    Parameters
+    ----------
+    ax : Axes
+        Matplotlib Axes object.
+    which : str, {"x", "y"}
+        The axis to apply the format to.
+    """
+    if which == "x":
+        axis = ax.xaxis
+        current_min, current_max = ax.get_xlim()
+    elif which == "y":
+        axis = ax.yaxis
+        current_min, current_max = ax.get_ylim()
+    else:
+        raise ValueError(f"Can only format x-axis or y-axis, not {which}")
+
+    if current_max > 4000 or current_min < -1000:
+        axis.set_major_formatter(EngFormatter())

--- a/dabl/plot/utils.py
+++ b/dabl/plot/utils.py
@@ -741,6 +741,7 @@ def plot_multiclass_roc_curve(estimator, X_val, y_val):
         ax.set_ylabel("True Positive Rate (recall)")
         ax.set_title("ROC curve for class {}".format(c))
 
+
 def _apply_eng_formatter(ax, which):
     """Apply engineering format to axis ticks.
 


### PR DESCRIPTION
Hi @amueller - Here's second of the small tweaks I mentioned to improve viz aesthetics after your talk at ODSC.

- Added ` _apply_eng_formatter()` utility function to determine whether/how to apply `matplotlib.ticker.EngFormatter` to the axis ticks
- Added formatting for plots with counts and continuous values that might be large

Examples:
<img width="393" alt="Screen Shot 2022-11-20 at 3 32 43 PM" src="https://user-images.githubusercontent.com/24376333/202924771-d1607384-a7c4-4900-a6ff-b6983ae23efe.png">
<img width="706" alt="Screen Shot 2022-11-20 at 3 32 58 PM" src="https://user-images.githubusercontent.com/24376333/202924787-20c75411-eed0-4017-85fa-e89f9f8b8dcb.png">
<img width="406" alt="Screen Shot 2022-11-20 at 3 33 46 PM" src="https://user-images.githubusercontent.com/24376333/202924825-66909f8a-8260-4f86-b0b7-c83f6df16962.png">
