### PR TITLE
Update the matrix of supported/tested combinations of sklearn and python used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
             scikit-learn-version: "1.4.*"
           - python-version: "3.8"
             scikit-learn-version: "1.5.*"
+          - python-version: "3.8"
+            scikit-learn-version: "dev"
           - python-version: "3.9"
             scikit-learn-version: "1.1.*"
           - python-version: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda update --yes -n base conda
-          conda install --yes pip pytest pytest-xdist numpy scipy wheel
+          conda install --yes pip pytest pytest-xdist wheel
           conda list
       - name: Install scikit-learn
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         if [ "$GITHUB_REF" == 'refs/heads/main' ] || [ "$GITHUB_EVENT_NAME" == 'schedule' ] || [ "$GITHUB_EVENT_NAME" == 'manual' ]; then
           echo '::set-output name=PythonVersionMatrix::["3.8", "3.9", "3.10", "3.11", "3.12"]'
         else
-          echo '::set-output name=PythonVersionMatrix::["3.8", "3.10"]'
+          echo '::set-output name=PythonVersionMatrix::["3.8", "3.10", "3.11", "3.12"]'
         fi
     - id: set-scikit-learn-version-matrix
       name: Determine scikit-learn version matrix
@@ -34,7 +34,7 @@ jobs:
         if [ "$GITHUB_REF" == 'refs/heads/main' ] || [ "$GITHUB_EVENT_NAME" == 'schedule' ] || [ "$GITHUB_EVENT_NAME" == 'manual' ]; then
           echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "1.3.*", "dev"]'
         else
-          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "dev"]'
+          echo '::set-output name=ScikitLearnVersionMatrix::["1.2.*", "dev"]'
         fi
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         if [ "$GITHUB_REF" == 'refs/heads/main' ] || [ "$GITHUB_EVENT_NAME" == 'schedule' ] || [ "$GITHUB_EVENT_NAME" == 'manual' ]; then
           echo '::set-output name=PythonVersionMatrix::["3.8", "3.9", "3.10", "3.11", "3.12"]'
         else
-          echo '::set-output name=PythonVersionMatrix::["3.8", "3.10", "3.11", "3.12"]'
+          echo '::set-output name=PythonVersionMatrix::["3.8", "3.10", "3.12"]'
         fi
     - id: set-scikit-learn-version-matrix
       name: Determine scikit-learn version matrix
@@ -34,7 +34,7 @@ jobs:
         if [ "$GITHUB_REF" == 'refs/heads/main' ] || [ "$GITHUB_EVENT_NAME" == 'schedule' ] || [ "$GITHUB_EVENT_NAME" == 'manual' ]; then
           echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "1.3.*", "1.4.*", "1.5.*", "dev"]'
         else
-          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "dev"]'
+          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "1.3.*", "dev"]'
         fi
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,27 @@ jobs:
         scikit-learn-version: ${{ fromJson(needs.prep-vars.outputs.ScikitLearnVersionMatrix) }}
         exclude:
           # Not supported:
+          # See Also: setup.py
+          - python-version: "3.8"
+            scikit-learn-version: "1.4.*"
+          - python-version: "3.8"
+            scikit-learn-version: "1.5.*"
+          - python-version: "3.9"
+            scikit-learn-version: "1.1.*"
+          - python-version: "3.9"
+            scikit-learn-version: "1.2.*"
+          - python-version: "3.10"
+            scikit-learn-version: "1.1.*"
+          - python-version: "3.10"
+            scikit-learn-version: "1.2.*"
+          - python-version: "3.11"
+            scikit-learn-version: "1.1.*"
+          - python-version: "3.11"
+            scikit-learn-version: "1.2.*"
           - python-version: "3.12"
             scikit-learn-version: "1.1.*"
+          - python-version: "3.12"
+            scikit-learn-version: "1.2.*"
 
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda update --yes -n base conda
-          conda install --yes pip pytest pytest-xdist wheel
+          conda install --yes pip pytest pytest-xdist wheel build
           conda list
       - name: Install scikit-learn
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       name: Determine scikit-learn version matrix
       run: |
         if [ "$GITHUB_REF" == 'refs/heads/main' ] || [ "$GITHUB_EVENT_NAME" == 'schedule' ] || [ "$GITHUB_EVENT_NAME" == 'manual' ]; then
-          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "1.3.*", "dev"]'
+          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "1.3.*", "1.4.*", "1.5.*", "dev"]'
         else
-          echo '::set-output name=ScikitLearnVersionMatrix::["1.2.*", "dev"]'
+          echo '::set-output name=ScikitLearnVersionMatrix::["1.1.*", "1.2.*", "dev"]'
         fi
 
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,11 @@
             "name": "Debug Unit Test",
             "type": "python",
             "request": "test",
-            "justMyCode": false
+            "justMyCode": false,
+            "env": {
+                // When debugging tests, only run a single pytest worker instance.
+                "PYTEST_ADDOPTS": "-n0 --dist=no --log-level=DEBUG",
+            }
         }
     ]
 }

--- a/dabl/_resample.py
+++ b/dabl/_resample.py
@@ -72,9 +72,11 @@ def resample(*arrays, **options):
              [2., 1.],
              [1., 0.]])
 
-      >>> X_sparse                   # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-      <3x2 sparse matrix of type '<... 'numpy.float64'>'
-          with 4 stored elements in Compressed Sparse Row format>
+      >>> X_sparse.shape
+      (3, 2)
+
+      >>> X_sparse.dtype
+      dtype('float64')
 
       >>> X_sparse.toarray()
       array([[1., 0.],

--- a/dabl/models.py
+++ b/dabl/models.py
@@ -7,6 +7,7 @@ import sklearn
 
 from sklearn.metrics import make_scorer, average_precision_score
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+import sklearn.metrics
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.multiclass import type_of_target
 from sklearn.pipeline import make_pipeline, Pipeline
@@ -157,7 +158,10 @@ class _BaseSimpleEstimator(_DablBaseEstimator):
         self.current_best_ = {rank_scoring: -np.inf}
         for est in estimators:
             set_random_state(est, self.random_state)
-            scorers = _check_multimetric_scoring(est, self.scoring_)
+            if _SKLEARN_VERSION >= '1.5':
+                scorers = sklearn.metrics.check_scoring(est, self.scoring_)
+            else:
+                scorers = _check_multimetric_scoring(est, self.scoring_)
             scores = self._evaluate_one(est, data_preproc, scorers)
             # make scoring configurable
             if scores[rank_scoring] > self.current_best_[rank_scoring]:

--- a/dabl/tests/test_models.py
+++ b/dabl/tests/test_models.py
@@ -31,6 +31,7 @@ def mock_get_estimators_dummy(self):
 def test_basic(X, y, refit):
     # test on iris
     ec = SimpleClassifier(refit=refit)
+    ec.verbose = 256
     ec.fit(X, y)
     if refit:
         # smoke test

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,8 +8,36 @@ scriptdir=$(dirname "$(readlink -f "$0")")
 cd "$scriptdir/.."
 
 for py_vers in 3.{8..12}; do
-    conda_env="dabl-py${py_vers}"
-    # Run pytest foreach supported version of python.
-    conda run -n $conda_env pytest -n auto -x --failed-first --new-first dabl/
+    for sklearn_vers in {1.1.*,1.2.*,1.3.*,1.4.*,1.5.*}; do
+        # Skip some unsupported version combos.
+        # See Also: setup.py
+        if [ $py_vers == "3.8" ] && [ $sklearn_vers == "1.4.*" ]; then
+            continue
+        elif [ $py_vers == "3.8" ] && [ $sklearn_vers == "1.5.*" ]; then
+            continue
+        elif [ $py_vers == "3.9" ] && [ $sklearn_vers == "1.1.*" ]; then
+            continue
+        elif [ $py_vers == "3.9" ] && [ $sklearn_vers == "1.2.*" ]; then
+            continue
+        elif [ $py_vers == "3.10" ] && [ $sklearn_vers == "1.1.*" ]; then
+            continue
+        elif [ $py_vers == "3.10" ] && [ $sklearn_vers == "1.2.*" ]; then
+            continue
+        elif [ $py_vers == "3.11" ] && [ $sklearn_vers == "1.1.*" ]; then
+            continue
+        elif [ $py_vers == "3.11" ] && [ $sklearn_vers == "1.2.*" ]; then
+            continue
+        elif [ $py_vers == "3.12" ] && [ $sklearn_vers == "1.1.*" ]; then
+            continue
+        elif [ $py_vers == "3.12" ] && [ $sklearn_vers == "1.2.*" ]; then
+            continue
+        fi
+        # Run the tests.
+        conda_env="dabl-py${py_vers}"
+        conda run -n $conda_env pip install -U scikit-learn==$sklearn_vers
+        conda run -n $conda_env pip check
+        # Run pytest foreach supported version of python.
+        conda run -n $conda_env pytest -n auto -x --failed-first --new-first dabl/
+    done
 done
 echo "OK"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,14 @@ setup(name='dabl',
           "numpy",
           "scipy",
           "scikit-learn>=1.1",
+
+          # Workaround (currently) undeclared numpy 2.x incompatibility with older
+          # scikit-learn versions.
+          # See Also: https://github.com/scikit-learn/scikit-learn/issues/29630
+          "numpy<2.0; python_version<'3.9'",
+          "scikit-learn<1.4; python_version<'3.9'",
+          "scikit-learn>=1.3; python_version>='3.9'",
+
           "pandas",
           "matplotlib < 3.8;python_version<'3.9'",
           "matplotlib >= 3.8;python_version>='3.9'",


### PR DESCRIPTION
Adjust the matrix of supported/tested numpy and sklearn versions.
Worksaround a missing version incompatibility declaration in older versions of sklearn.
See Also: https://github.com/scikit-learn/scikit-learn/issues/29630
Additionally, applies a handful of small fixups for newer versions of sklearn so tests pass again.